### PR TITLE
Add radiko Premium authenticate

### DIFF
--- a/bin/radikorec
+++ b/bin/radikorec
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import re
 import commands
 from argparse import ArgumentParser
 
@@ -22,6 +23,12 @@ class Config:
 		
 	def P(self, msg):
 		LOGFILE = "/tmp/radikorec.log"
+
+		# Hide if contains id and pass
+		msg = str(msg)
+		msg = re.sub("id='.*?'", r"id='*****'", msg)
+		msg = re.sub("password='.*?'", r"password='*****'", msg)
+
 		f = open(LOGFILE, "a")
 		f.write(str(msg) + "\n")
 		f.close
@@ -46,6 +53,10 @@ if __name__ == '__main__':
 	parser.add_argument('--directory', default='/tmp', help="output directory. default(/tmp)")
 	parser.add_argument('--debug', action='store_true', default=False, help="print messages on console.")
 	parser.add_argument('--dry-run', action='store_true', default=False, help="don't actually execute")
+
+	parser.add_argument('--premium', action='store_true', default=False, help="use Radiko Premium Authentication(--id and --password is required)")
+	parser.add_argument('--id', default=None, help="Radiko Premium ID")
+	parser.add_argument('--password', default=None, help="Radiko Premium Password")
 	
 	args = parser.parse_args()
 	
@@ -59,6 +70,11 @@ if __name__ == '__main__':
 		command1 = radiru.getCommand1(config)
 	else:		
 		config.P("use RADIKO")
+		if config.args.premium:
+			radiko.login(config)
+		else:
+			radiko.logout(config)
+
 		command1 = radiko.getCommand1(config)
 		
 	if command1 is None:
@@ -73,7 +89,7 @@ if __name__ == '__main__':
 			repeat += 1
 		else:		
 			break
-		
+
 	if repeat is 10:
 		config.P("ERROR all command1 retries failed")
 		exit(1)

--- a/lib/radiko.py
+++ b/lib/radiko.py
@@ -5,8 +5,81 @@ import commands
 
 import xml.etree.ElementTree as ET
 
+cookiefile = "/tmp/radiko_cookie"
+
+def login(config):
+	if os.path.exists(cookiefile):
+		is_login = check(config)
+		if is_login:
+			config.P("INFO: already logged-in")
+			return
+		else:
+			config.P("WARN: cookie is expired or not login")
+
+	login_id = config.args.id
+	login_pass = config.args.password
+
+	command = """\
+wget -q \
+--header="pragma: no-cache" \
+--post-data='mail=%s&pass=%s' \
+--no-check-certificate \
+--save-cookies=%s \
+https://radiko.jp/ap/member/login/login
+""".strip() % (login_id, login_pass, cookiefile)
+
+	r = config.R(command)
+
+	if (r is not 0) or not os.path.exists(cookiefile):
+		config.P("ERROR login failed")
+		exit(1)
+
+	config.P("login OK")
+
+
+def logout(config):
+	if not os.path.exists(cookiefile):
+		return
+
+	command = """\
+wget -q \
+--header="pragma: no-cache" \
+--no-check-certificate \
+--load-cookies=%s \
+http://radiko.jp/ap/member/webapi/member/logout
+""".strip() % (cookiefile)
+	
+	r = config.R(command)
+
+	if (r is not 0):
+		config.P("WARN: logout failed (not logged-in?)")
+
+	config.R("rm " + cookiefile)
+	config.P("logout OK")
+
+
+def check(config):
+	command = """\
+wget -q \
+--header="pragma: no-cache" \
+--no-check-certificate \
+--load-cookies=%s \
+--save-cookies=%s \
+http://radiko.jp/ap/member/webapi/member/login/check
+""".strip() % (cookiefile,cookiefile)
+
+	r = config.R(command)
+
+	if(r is not 0):
+		config.P("check is failed(LOGOUT or EXPIRED?)")
+		return False
+	else:
+		config.P("check is success")
+		return True
+
+
 def getCommand1(config):
-	playerurl="http://radiko.jp/player/swf/player_3.0.0.01.swf"
+	playerurl="http://radiko.jp/player/swf/player_4.1.0.00.swf"
 	playerfile="/tmp/radiko_player.swf"
 	keyfile="/tmp/radiko_authkey.png"
 
@@ -38,10 +111,12 @@ wget -q \
 --header="X-Radiko-Device: pc" \
 --post-data='\r\n' \
 --no-check-certificate \
+--load-cookies=%s \
 --save-headers \
 https://radiko.jp/v2/api/auth1_fms
-"""
-	r = config.R(command)			
+""".strip() % (cookiefile)
+
+	r = config.R(command)
 
 	if (r is not 0) or not os.path.exists("auth1_fms"):
 		config.P("ERROR auth1 failed")
@@ -106,8 +181,9 @@ wget -q \
 --header="X-Radiko-Partialkey: %s" \
 --post-data='\r\n' \
 --no-check-certificate \
+--load-cookies=%s \
 https://radiko.jp/v2/api/auth2_fms
-""".strip() % (authtoken, partialkey)
+""".strip() % (authtoken, partialkey, cookiefile)
 	r = config.R(command)
 
 	if (r is not 0) or not os.path.exists("auth2_fms"):
@@ -133,7 +209,7 @@ https://radiko.jp/v2/api/auth2_fms
 		
 	command = """ \
 wget \
--q "http://radiko.jp/v2/station/stream/%s"
+-q "http://radiko.jp/v2/station/stream_multi/%s"
 """.strip() % xmlFile
 	config.R(command)	
 
@@ -143,7 +219,12 @@ wget \
 	f.close()
 
 	root = ET.fromstring(text)
-	stream_url = root[0].text
+
+	if config.args.premium:
+		stream_url = root.find(".//item[@areafree='1']").text
+	else:
+		stream_url = root.find(".//item[@areafree='0']").text
+
 	config.P("stream_url: %s" % stream_url)
 
 	pat = re.compile(r"^(.+)://(.+?)/(.*)/(.*?)$")

--- a/lib/radiko.py
+++ b/lib/radiko.py
@@ -25,6 +25,7 @@ wget -q \
 --post-data='mail=%s&pass=%s' \
 --no-check-certificate \
 --save-cookies=%s \
+-O - \
 https://radiko.jp/ap/member/login/login
 """.strip() % (login_id, login_pass, cookiefile)
 
@@ -46,6 +47,7 @@ wget -q \
 --header="pragma: no-cache" \
 --no-check-certificate \
 --load-cookies=%s \
+-O - \
 http://radiko.jp/ap/member/webapi/member/logout
 """.strip() % (cookiefile)
 	
@@ -65,6 +67,7 @@ wget -q \
 --no-check-certificate \
 --load-cookies=%s \
 --save-cookies=%s \
+-O - \
 http://radiko.jp/ap/member/webapi/member/login/check
 """.strip() % (cookiefile,cookiefile)
 


### PR DESCRIPTION
How to use:

```
radikorec --premium --id=test@example.com --pass=password --channel=QRR --duration=1
```

Warning:
Fear of id(=mail address) and password leak...

---

radikoプレミアムの認証を行えるようにしてみました。使い方は↑を参照してください。

僕の実力不足で申し訳ないのですが、IDとパスワードのログが残って漏れる危険性があります。(shellのhistoryとか/tmp/radikorec.logとか)
ある程度は対策してあります（ bin/radikorec #26-31 ）が、不完全かも知れません。
PR提出してご助言・ご指摘を頂ければと思います。
