### PR TITLE
Add radiru OSAKA, SENDAI and NAGOYA channel.

### DIFF
--- a/lib/radiru.py
+++ b/lib/radiru.py
@@ -2,6 +2,12 @@ CHANNEL_MAP = {
 	"FM"   : ("fm", 63343), 
 	"NHK1" : ("r1", 63346), 
 	"NHK2" : ("r2", 63342),
+	"FM_SENDAI"   : ("hkfm", 108237),
+	"NHK1_SENDAI" : ("hkr1", 108442),
+	"FM_NAGOYA"   : ("ckfm", 108235),
+	"NHK1_NAGOYA" : ("ckr1", 108234),
+	"FM_OSAKA"    : ("bkfm", 108233),
+	"NHK1_OSAKA"  : ("bkr1", 108232),
 }
 
 def getCommand1(config):


### PR DESCRIPTION
NHK R2 is not added beacause NHK R2 is same url as TOKYO.

---

らじるらじるの地方局(仙台、名古屋、大阪)の受信に対応させました。
なおNHKラジオ第2はどの地方でも単一のサーバーのみ(63342)となっているため追加しませんでした。
